### PR TITLE
Bugfix: 403-errors display incorrect HTML due to a misplaced closing PHP-tag

### DIFF
--- a/403.php
+++ b/403.php
@@ -1,16 +1,15 @@
 <?php
 /**
- * The template for displaying 404 pages (Zugriff nicht erlaubt).
+ * The template for displaying 403 pages (Zugriff nicht erlaubt).
  *
  * @package WordPress
  * @subpackage FAU
  * @since FAU 1.0
  */
 
+get_header();
 $error_hidedefaultnotice = get_theme_mod('advanced_error_sidebar_hidedefaultnotice');
 
-?>
-get_header();
 ?>
  <div id="content">
     <div class="content-container">	   


### PR DESCRIPTION
Without the patch the error can be triggered on this site:
https://www.tf.fau.de/?status=403